### PR TITLE
Update dependency versions

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,8 +25,8 @@ dependencies:
     sdk: flutter
   firestore_cache:
     path: ../
-  cloud_firestore: ^0.14.0+2
-  firebase_core: ^0.5.0
+  cloud_firestore: ^0.16.0
+  firebase_core: ^0.7.0
 
 dev_dependencies:
   flutter_test:
@@ -67,4 +67,3 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
-

--- a/lib/src/firestore_cache.dart
+++ b/lib/src/firestore_cache.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'exceptions.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ">=0.14.0 <0.15.0"
-  meta: ">=1.0.0 <1.3.1"
+  cloud_firestore: ">=0.16.0 <0.17.0"
   shared_preferences: ">=0.5.0 <2.0.0"
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  cloud_firestore_mocks: ^0.5.2
+  cloud_firestore_mocks: ^0.6.0


### PR DESCRIPTION
- Update `cloud_firestore` version constraint to `>=0.16.0 <0.17.0`
- Remove `meta` as a dependency
- Update example dependency versions
- Closes #31 