### PR TITLE
Fix data type mismatch with cloud_firestore types

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,8 +31,8 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   final _firestore = FirebaseFirestore.instance;
-  late Future<DocumentSnapshot> _futureDoc;
-  late Future<QuerySnapshot> _futureSnapshot;
+  late Future<DocumentSnapshot<Map<String, dynamic>>> _futureDoc;
+  late Future<QuerySnapshot<Map<String, dynamic>>> _futureSnapshot;
 
   @override
   void initState() {
@@ -104,14 +104,14 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  Future<DocumentSnapshot> _getDoc() async {
+  Future<DocumentSnapshot<Map<String, dynamic>>> _getDoc() async {
     final docRef = _firestore.doc('users/user');
     final doc = await FirestoreCache.getDocument(docRef);
 
     return doc;
   }
 
-  Future<QuerySnapshot> _getDocs() async {
+  Future<QuerySnapshot<Map<String, dynamic>>> _getDocs() async {
     final cacheDocRef = _firestore.doc('status/status');
     final cacheField = 'updatedAt';
     final query = _firestore.collection('posts');

--- a/lib/src/firestore_cache.dart
+++ b/lib/src/firestore_cache.dart
@@ -36,12 +36,12 @@ class FirestoreCache {
   ///
   /// This method should only be used if the document you are fetching does not change
   /// over time. Once the document is cached, it will always be read from the cache.
-  static Future<DocumentSnapshot> getDocument(
-    DocumentReference docRef, {
+  static Future<DocumentSnapshot<Map<String, dynamic>>> getDocument(
+    DocumentReference<Map<String, dynamic>> docRef, {
     Source source = Source.cache,
     bool isRefreshEmptyCache = true,
   }) async {
-    DocumentSnapshot doc;
+    DocumentSnapshot<Map<String, dynamic>> doc;
     try {
       doc = await docRef.get(GetOptions(source: source));
       if (doc.data() == null && isRefreshEmptyCache) doc = await docRef.get();
@@ -61,9 +61,9 @@ class FirestoreCache {
   /// You can also pass in [localCacheKey] as the key for storing the last local
   /// cache date, and [isUpdateCacheDate] to set if it should update the last local
   /// cache date to current date and time.
-  static Future<QuerySnapshot> getDocuments({
-    required Query query,
-    required DocumentReference cacheDocRef,
+  static Future<QuerySnapshot<Map<String, dynamic>>> getDocuments({
+    required Query<Map<String, dynamic>> query,
+    required DocumentReference<Map<String, dynamic>> cacheDocRef,
     required String firestoreCacheField,
     String? localCacheKey,
     bool isUpdateCacheDate = true,
@@ -100,7 +100,7 @@ class FirestoreCache {
 
   @visibleForTesting
   static Future<bool> isFetchDocuments(
-    DocumentReference cacheDocRef,
+    DocumentReference<Map<String, dynamic>> cacheDocRef,
     String firestoreCacheField,
     String localCacheKey,
   ) async {
@@ -111,7 +111,7 @@ class FirestoreCache {
     if (dateStr != null) {
       final cacheDate = DateTime.parse(dateStr);
       final doc = await cacheDocRef.get();
-      final data = doc.data() as Map?;
+      final data = doc.data();
 
       if (!doc.exists) {
         throw CacheDocDoesNotExist();

--- a/test/firestore_cache_test.dart
+++ b/test/firestore_cache_test.dart
@@ -5,33 +5,35 @@ import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 // ignore: subtype_of_sealed_class
-class MockQuery extends Mock implements Query {}
+class MockQuery<Map> extends Mock implements Query<Map> {}
 
-class MockQuerySnapshot extends Mock implements QuerySnapshot {}
-
-// ignore: subtype_of_sealed_class
-class MockQueryDocumentSnapshot extends Mock implements QueryDocumentSnapshot {}
-
-class MockDocumentReference extends Mock implements DocumentReference {}
+class MockQuerySnapshot<Map> extends Mock implements QuerySnapshot<Map> {}
 
 // ignore: subtype_of_sealed_class
-class MockDocumentSnapshot extends Mock implements DocumentSnapshot {}
+class MockQueryDocumentSnapshot<Map> extends Mock
+    implements QueryDocumentSnapshot<Map> {}
+
+class MockDocumentReference<Map> extends Mock
+    implements DocumentReference<Map> {}
+
+// ignore: subtype_of_sealed_class
+class MockDocumentSnapshot<Map> extends Mock implements DocumentSnapshot<Map> {}
 
 class MockSnapshotMetadata extends Mock implements SnapshotMetadata {}
 
 void main() {
   final data = {'firestore': 'cache'};
   final cacheField = 'updatedAt';
-  final mockCacheDocRef = MockDocumentReference();
-  final mockCacheSnapshot = MockDocumentSnapshot();
+  final mockCacheDocRef = MockDocumentReference<Map<String, dynamic>>();
+  final mockCacheSnapshot = MockDocumentSnapshot<Map<String, dynamic>>();
 
   when(() => mockCacheDocRef.get()).thenAnswer((_) {
     return Future.value(mockCacheSnapshot);
   });
 
   group('testGetDocument', () {
-    final mockDocRef = MockDocumentReference();
-    final mockSnapshot = MockDocumentSnapshot();
+    final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
+    final mockSnapshot = MockDocumentSnapshot<Map<String, dynamic>>();
     final mockMetadata = MockSnapshotMetadata();
 
     when(() => mockSnapshot.data()).thenReturn(data);
@@ -74,7 +76,7 @@ void main() {
     });
 
     test('testGetFromCacheFallbackToServer', () async {
-      final mockDocRef = MockDocumentReference();
+      final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
 
       when(() => mockDocRef.get(any())).thenThrow(
         FirebaseException(plugin: 'test'),
@@ -98,8 +100,8 @@ void main() {
     });
 
     test('testGetFromCacheNullAndRefresh', () async {
-      final mockDocRef = MockDocumentReference();
-      final mockSnapshotNull = MockDocumentSnapshot();
+      final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
+      final mockSnapshotNull = MockDocumentSnapshot<Map<String, dynamic>>();
 
       when(() => mockDocRef.get(any())).thenAnswer((_) {
         return Future.value(mockSnapshotNull);
@@ -125,8 +127,8 @@ void main() {
     });
 
     test('testGetFromCacheNullAndNotRefresh', () async {
-      final mockDocRef = MockDocumentReference();
-      final mockSnapshotNull = MockDocumentSnapshot();
+      final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
+      final mockSnapshotNull = MockDocumentSnapshot<Map<String, dynamic>>();
 
       when(() => mockDocRef.get(any())).thenAnswer((_) {
         return Future.value(mockSnapshotNull);
@@ -148,10 +150,10 @@ void main() {
   });
 
   group('testGetDocuments', () {
-    final mockQuery = MockQuery();
-    final mockQuerySnapshot = MockQuerySnapshot();
+    final mockQuery = MockQuery<Map<String, dynamic>>();
+    final mockQuerySnapshot = MockQuerySnapshot<Map<String, dynamic>>();
     final mockQueryMetadata = MockSnapshotMetadata();
-    final mockDocSnapshot = MockQueryDocumentSnapshot();
+    final mockDocSnapshot = MockQueryDocumentSnapshot<Map<String, dynamic>>();
     final mockDocMetadata = MockSnapshotMetadata();
 
     when(() => mockQuerySnapshot.docs).thenReturn([mockDocSnapshot]);
@@ -192,8 +194,8 @@ void main() {
     });
 
     test('testGetFromCacheFallbackToServer', () async {
-      final mockQuery = MockQuery();
-      final emptyMockQuerySnapshot = MockQuerySnapshot();
+      final mockQuery = MockQuery<Map<String, dynamic>>();
+      final emptyMockQuerySnapshot = MockQuerySnapshot<Map<String, dynamic>>();
 
       when(() => mockQuery.get(any())).thenAnswer((_) {
         return Future.value(emptyMockQuerySnapshot);


### PR DESCRIPTION
- Add `Map<String, dynamic>` to `cloud_firestore` types, which includes `DocumentRefreence`, `DocumentSnapshot`, `Query` and `QuerySnapshot`
- Fixed #52 