### PR TITLE
Add to parse server date string type

### DIFF
--- a/lib/src/firestore_cache.dart
+++ b/lib/src/firestore_cache.dart
@@ -119,8 +119,18 @@ class FirestoreCache {
         throw CacheDocFieldDoesNotExist();
       }
 
-      final DateTime latestDate = data[firestoreCacheField].toDate();
-      if (latestDate.isBefore(cacheDate)) {
+      final serverDateRaw = data[firestoreCacheField];
+      DateTime? serverDate;
+
+      if (serverDateRaw is Timestamp) {
+        serverDate = serverDateRaw.toDate();
+      } else if (serverDateRaw is String) {
+        serverDate = DateTime.tryParse(serverDateRaw);
+      }
+
+      if (serverDate == null) {
+        throw FormatException('Invalid date format', serverDateRaw);
+      } else if (serverDate.isBefore(cacheDate) == true) {
         isFetch = false;
       }
     }

--- a/lib/src/firestore_cache.dart
+++ b/lib/src/firestore_cache.dart
@@ -57,7 +57,14 @@ class FirestoreCache {
   ///
   /// This method takes in a [query] which is the usual Firestore [Query] object
   /// used to query a collection, and a [cacheDocRef] which is the [DocumentReference]
-  /// object of the document containing a [firestoreCacheField] field of timestamp.
+  /// object of the document containing a [firestoreCacheField] field
+  /// of [Timestamp] or [String]. If the field is a [String], it must be parsable by
+  /// [DateTime.parse]. Otherwise [FormatException] will be thrown.
+  ///
+  /// If [cacheDocRef] does not exist, [CacheDocDoesNotExist] will be thrown.
+  /// And if [firestoreCacheField] does not exist, [CacheDocFieldDoesNotExist]
+  /// will be thrown.
+  ///
   /// You can also pass in [localCacheKey] as the key for storing the last local
   /// cache date, and [isUpdateCacheDate] to set if it should update the last local
   /// cache date to current date and time.

--- a/test/firestore_cache_test.dart
+++ b/test/firestore_cache_test.dart
@@ -284,6 +284,25 @@ void main() {
       expect(result, true);
     });
 
+    test('testServerDateString', () async {
+      final now = DateTime.now();
+      SharedPreferences.setMockInitialValues({
+        cacheField: now.toIso8601String(),
+      });
+      final updatedAt = now.add(Duration(seconds: 1));
+      when(() => mockCacheSnapshot.data()).thenReturn({
+        cacheField: updatedAt.toIso8601String(),
+      });
+
+      final result = await FirestoreCache.isFetchDocuments(
+        mockCacheDocRef,
+        cacheField,
+        cacheField,
+      );
+
+      expect(result, true);
+    });
+
     test('testCacheDocRefNotExist', () async {
       final now = DateTime.now();
       SharedPreferences.setMockInitialValues({
@@ -317,6 +336,25 @@ void main() {
           cacheField,
         ),
         throwsA(isInstanceOf<CacheDocFieldDoesNotExist>()),
+      );
+    });
+
+    test('testInvalidServerDateFormat', () async {
+      final now = DateTime.now();
+      SharedPreferences.setMockInitialValues({
+        cacheField: now.toIso8601String(),
+      });
+      when(() => mockCacheSnapshot.data()).thenReturn({
+        cacheField: 'invalidDateFormat',
+      });
+
+      expect(
+        () async => await FirestoreCache.isFetchDocuments(
+          mockCacheDocRef,
+          cacheField,
+          cacheField,
+        ),
+        throwsA(isInstanceOf<FormatException>()),
       );
     });
   });


### PR DESCRIPTION
- For `getDocuments`, add to try and parse the `firestoreCacheField` in `cacheDocRef` from `String` into `DateTime`
  - This function will now throw `FormatException` if it can't parse `firebaseCacheField` into `DateTime`
  - This new feature will address #55